### PR TITLE
Rails 5.2 compatiblity

### DIFF
--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -22,7 +22,7 @@ meaning they should be as close to the original CSS syntax as possible.
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency("sass", "~> 3.4")
-  s.add_runtime_dependency("thor", "~> 0.19")
+  s.add_runtime_dependency("thor")
 
   s.add_development_dependency("aruba", "~> 0.6.2")
   s.add_development_dependency("css_parser", "~> 1.3")


### PR DESCRIPTION
WHY:
To be able to use Conduit gem with Rails 5.2

HOW:
Bump thor dependency